### PR TITLE
Feature / [19] Match dropdown style with inputs

### DIFF
--- a/components/SummaryForm.js
+++ b/components/SummaryForm.js
@@ -76,7 +76,7 @@ const SummaryForm = ({ summary, sheets, onChange, onExperienceChange, onAddExp, 
                     <select
                         value={summary.applied_for || ''}
                         onChange={(e) => onChange('applied_for', e.target.value)}
-                        className="mt-1 block w-full border rounded px-3 py-2">
+                        className="mt-1 block w-full border rounded px-3 py-2 bg-white appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500">
                         <option value="">Select job</option>
                         {JOB_OPTIONS.map((job) => (
                             <option key={job} value={job}>
@@ -133,10 +133,12 @@ const SummaryForm = ({ summary, sheets, onChange, onExperienceChange, onAddExp, 
                     <select
                         value={summary.sheet || ''}
                         onChange={(e) => onChange('sheet', e.target.value)}
-                        className="mt-1 block w-full border rounded px-3 py-2">
+                        className="mt-1 block w-full border rounded px-3 py-2 bg-white appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500">
                         <option value="">Select sheet</option>
                         {sheets.map((sheet) => (
-                            <option key={sheet} value={sheet}>{sheet}</option>
+                            <option key={sheet} value={sheet}>
+                                {sheet}
+                            </option>
                         ))}
                     </select>
                 </label>


### PR DESCRIPTION
Fixes: https://github.com/smaria03/cvparser-backend/issues/19

**Changes**
Updated the Applied For and Sheet select fields to use the same styling as input fields.

**Before**
<img width="1275" height="82" alt="Screenshot 2025-09-18 at 19 24 47" src="https://github.com/user-attachments/assets/e97c56f5-6e01-4745-ac5c-1ae7249c9202" />


**After**
￼<img width="1277" height="97" alt="Screenshot 2025-09-18 at 19 25 11" src="https://github.com/user-attachments/assets/be0cb5d3-83ae-404a-a914-a2bb763a35ad" />